### PR TITLE
feat: add Room CRUD module with relations

### DIFF
--- a/backend/server/src/app.module.ts
+++ b/backend/server/src/app.module.ts
@@ -5,9 +5,10 @@ import { PrismaModule } from './prisma/prisma.module';
 import { CompanyModule } from './company/company.module';
 import { BuildingModule } from './building/building.module';
 import { FloorModule } from './floor/floor.module';
+import { RoomModule } from './room/room.module';
 
 @Module({
-  imports: [PrismaModule, CompanyModule, BuildingModule, FloorModule],
+  imports: [PrismaModule, CompanyModule, BuildingModule, FloorModule, RoomModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/server/src/room/dto/create-room.dto.ts
+++ b/backend/server/src/room/dto/create-room.dto.ts
@@ -1,0 +1,19 @@
+import { IsInt, IsOptional } from 'class-validator';
+
+export class CreateRoomDto {
+  // Required because `room_id` has no autoincrement in Prisma schema
+  @IsInt()
+  room_id!: number;
+
+  @IsOptional()
+  @IsInt()
+  floor_id?: number | null;
+
+  @IsOptional()
+  @IsInt()
+  cell_row?: number | null;
+
+  @IsOptional()
+  @IsInt()
+  cell_column?: number | null;
+}

--- a/backend/server/src/room/dto/update-room.dto.ts
+++ b/backend/server/src/room/dto/update-room.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsOptional } from 'class-validator';
+
+export class UpdateRoomDto {
+  @IsOptional()
+  @IsInt()
+  floor_id?: number | null;
+
+  @IsOptional()
+  @IsInt()
+  cell_row?: number | null;
+
+  @IsOptional()
+  @IsInt()
+  cell_column?: number | null;
+}

--- a/backend/server/src/room/room.controller.ts
+++ b/backend/server/src/room/room.controller.ts
@@ -1,0 +1,44 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post } from '@nestjs/common';
+import { RoomService } from './room.service';
+import { CreateRoomDto } from './dto/create-room.dto';
+import { UpdateRoomDto } from './dto/update-room.dto';
+
+@Controller('room')
+export class RoomController {
+  constructor(private readonly roomService: RoomService) {}
+
+  @Post()
+  create(@Body() dto: CreateRoomDto) {
+    return this.roomService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.roomService.findAll();
+  }
+
+  @Get('with-relations')
+  findAllWithRelations() {
+    return this.roomService.findAllWithRelations();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.roomService.findOne(id);
+  }
+
+  @Get(':id/with-relations')
+  findOneWithRelations(@Param('id', ParseIntPipe) id: number) {
+    return this.roomService.findOneWithRelations(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateRoomDto) {
+    return this.roomService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.roomService.remove(id);
+  }
+}

--- a/backend/server/src/room/room.module.ts
+++ b/backend/server/src/room/room.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RoomService } from './room.service';
+import { RoomController } from './room.controller';
+
+@Module({
+  controllers: [RoomController],
+  providers: [RoomService],
+  exports: [RoomService],
+})
+export class RoomModule {}

--- a/backend/server/src/room/room.service.ts
+++ b/backend/server/src/room/room.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateRoomDto } from './dto/create-room.dto';
+import { UpdateRoomDto } from './dto/update-room.dto';
+
+@Injectable()
+export class RoomService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateRoomDto) {
+    const data: any = {
+      room_id: dto.room_id,
+      floor_id: dto.floor_id ?? undefined,
+      cell_row: dto.cell_row ?? undefined,
+      cell_column: dto.cell_column ?? undefined,
+    };
+    return this.prisma.room.create({ data });
+  }
+
+  async findAll() {
+    return this.prisma.room.findMany();
+  }
+
+  async findOne(room_id: number) {
+    const room = await this.prisma.room.findUnique({ where: { room_id } });
+    if (!room) throw new NotFoundException(`Room ${room_id} not found`);
+    return room;
+  }
+
+  async findAllWithRelations() {
+    return this.prisma.room.findMany({
+      include: {
+        floor: true,
+        table: true,
+      },
+    });
+  }
+
+  async findOneWithRelations(room_id: number) {
+    const room = await this.prisma.room.findUnique({
+      where: { room_id },
+      include: {
+        floor: true,
+        table: true,
+      },
+    });
+    if (!room) throw new NotFoundException(`Room ${room_id} not found`);
+    return room;
+  }
+
+  async update(room_id: number, dto: UpdateRoomDto) {
+    const data: any = {
+      floor_id: dto.floor_id ?? undefined,
+      cell_row: dto.cell_row ?? undefined,
+      cell_column: dto.cell_column ?? undefined,
+    };
+    return this.prisma.room.update({ where: { room_id }, data });
+  }
+
+  async remove(room_id: number) {
+    return this.prisma.room.delete({ where: { room_id } });
+  }
+}


### PR DESCRIPTION
## Overview
This PR introduces the **Room module** to the backend.  
It provides full CRUD operations and relation-based queries with Floor and Tables.

## Changes
- Added DTOs (`create-room.dto.ts`, `update-room.dto.ts`)
- Implemented Room service with:
  - Standard CRUD
  - `/with-relations` support (includes Floor and Tables)
- Created Room controller with CRUD + relation endpoints
- Registered Room module in `app.module.ts`

## Testing
- Verified Room CRUD endpoints (create, read, update, delete)
- Tested `/room/with-relations` to ensure Floor and Tables are included
- Checked database integration with existing Floor and Table entities

## Notes
- Next step: ensure consistency of relations when Floor/Room/Table data changes
- CRLF warnings are only line-ending conversions, safe to ignore
