### PR TITLE
feat: add Table CRUD module with Room relation

### DIFF
--- a/backend/server/src/app.module.ts
+++ b/backend/server/src/app.module.ts
@@ -6,9 +6,10 @@ import { CompanyModule } from './company/company.module';
 import { BuildingModule } from './building/building.module';
 import { FloorModule } from './floor/floor.module';
 import { RoomModule } from './room/room.module';
+import { TableModule } from './table/table.module';
 
 @Module({
-  imports: [PrismaModule, CompanyModule, BuildingModule, FloorModule, RoomModule],
+  imports: [PrismaModule, CompanyModule, BuildingModule, FloorModule, RoomModule, TableModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/server/src/table/dto/create-table.dto.ts
+++ b/backend/server/src/table/dto/create-table.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class CreateTableDto {
+  // Required because `table_id` has no autoincrement in Prisma schema
+  @IsInt()
+  table_id!: number;
+
+  @IsOptional()
+  @IsInt()
+  room_id?: number | null;
+
+  @IsOptional()
+  @IsString()
+  posittion?: string | null;
+}

--- a/backend/server/src/table/dto/update-table.dto.ts
+++ b/backend/server/src/table/dto/update-table.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class UpdateTableDto {
+  @IsOptional()
+  @IsInt()
+  room_id?: number | null;
+
+  @IsOptional()
+  @IsString()
+  posittion?: string | null;
+}

--- a/backend/server/src/table/table.controller.ts
+++ b/backend/server/src/table/table.controller.ts
@@ -1,0 +1,44 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post } from '@nestjs/common';
+import { TableService } from './table.service';
+import { CreateTableDto } from './dto/create-table.dto';
+import { UpdateTableDto } from './dto/update-table.dto';
+
+@Controller('table')
+export class TableController {
+  constructor(private readonly tableService: TableService) {}
+
+  @Post()
+  create(@Body() dto: CreateTableDto) {
+    return this.tableService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.tableService.findAll();
+  }
+
+  @Get('with-relations')
+  findAllWithRelations() {
+    return this.tableService.findAllWithRelations();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.tableService.findOne(id);
+  }
+
+  @Get(':id/with-relations')
+  findOneWithRelations(@Param('id', ParseIntPipe) id: number) {
+    return this.tableService.findOneWithRelations(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateTableDto) {
+    return this.tableService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.tableService.remove(id);
+  }
+}

--- a/backend/server/src/table/table.module.ts
+++ b/backend/server/src/table/table.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TableService } from './table.service';
+import { TableController } from './table.controller';
+
+@Module({
+  controllers: [TableController],
+  providers: [TableService],
+  exports: [TableService],
+})
+export class TableModule {}

--- a/backend/server/src/table/table.service.ts
+++ b/backend/server/src/table/table.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateTableDto } from './dto/create-table.dto';
+import { UpdateTableDto } from './dto/update-table.dto';
+
+@Injectable()
+export class TableService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateTableDto) {
+    const data: any = {
+      table_id: dto.table_id,
+      room_id: dto.room_id ?? undefined,
+      posittion: dto.posittion ?? undefined,
+    };
+    return this.prisma.table.create({ data });
+  }
+
+  async findAll() {
+    return this.prisma.table.findMany();
+  }
+
+  async findOne(table_id: number) {
+    const table = await this.prisma.table.findUnique({ where: { table_id } });
+    if (!table) throw new NotFoundException(`Table ${table_id} not found`);
+    return table;
+  }
+
+  async findAllWithRelations() {
+    return this.prisma.table.findMany({
+      include: {
+        room: true,
+      },
+    });
+  }
+
+  async findOneWithRelations(table_id: number) {
+    const table = await this.prisma.table.findUnique({
+      where: { table_id },
+      include: {
+        room: true,
+      },
+    });
+    if (!table) throw new NotFoundException(`Table ${table_id} not found`);
+    return table;
+  }
+
+  async update(table_id: number, dto: UpdateTableDto) {
+    const data: any = {
+      room_id: dto.room_id ?? undefined,
+      posittion: dto.posittion ?? undefined,
+    };
+    return this.prisma.table.update({ where: { table_id }, data });
+  }
+
+  async remove(table_id: number) {
+    return this.prisma.table.delete({ where: { table_id } });
+  }
+}


### PR DESCRIPTION
## Overview
This PR introduces the Table module to the backend.

## Changes
- Added Table entity with optional relation to Room
- Generated DTOs for create/update operations
- Implemented Table service and controller with standard CRUD
- Registered Table module in AppModule

## Testing
- Verified all Table CRUD endpoints via Postman
- Confirmed Room relation works when assigning a table to a room
- No deep includes beyond Room

## Notes
- Relation integrity will be validated in future tasks (Room ↔ Table consistency)
