### PR TITLE
feat: implement RenamedFunction CRUD module with relations

### DIFF
--- a/backend/server/src/app.module.ts
+++ b/backend/server/src/app.module.ts
@@ -7,9 +7,10 @@ import { BuildingModule } from './building/building.module';
 import { FloorModule } from './floor/floor.module';
 import { RoomModule } from './room/room.module';
 import { TableModule } from './table/table.module';
+import { RenamedfunctionModule } from './renamedfunction/renamedfunction.module';
 
 @Module({
-  imports: [PrismaModule, CompanyModule, BuildingModule, FloorModule, RoomModule, TableModule],
+  imports: [PrismaModule, CompanyModule, BuildingModule, FloorModule, RoomModule, TableModule, RenamedfunctionModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/server/src/renamedfunction/dto/create-renamedfunction.dto.ts
+++ b/backend/server/src/renamedfunction/dto/create-renamedfunction.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class CreateRenamedfunctionDto {
+  // Required because `function_id` has no autoincrement in Prisma schema
+  @IsInt()
+  function_id!: number;
+
+  @IsOptional()
+  @IsInt()
+  building_id?: number | null;
+
+  @IsOptional()
+  @IsString()
+  name?: string | null;
+}

--- a/backend/server/src/renamedfunction/dto/update-renamedfunction.dto.ts
+++ b/backend/server/src/renamedfunction/dto/update-renamedfunction.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class UpdateRenamedfunctionDto {
+  @IsOptional()
+  @IsInt()
+  building_id?: number | null;
+
+  @IsOptional()
+  @IsString()
+  name?: string | null;
+}

--- a/backend/server/src/renamedfunction/renamedfunction.controller.ts
+++ b/backend/server/src/renamedfunction/renamedfunction.controller.ts
@@ -1,0 +1,44 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post } from '@nestjs/common';
+import { RenamedfunctionService } from './renamedfunction.service';
+import { CreateRenamedfunctionDto } from './dto/create-renamedfunction.dto';
+import { UpdateRenamedfunctionDto } from './dto/update-renamedfunction.dto';
+
+@Controller('renamedfunction')
+export class RenamedfunctionController {
+  constructor(private readonly renamedfunctionService: RenamedfunctionService) {}
+
+  @Post()
+  create(@Body() dto: CreateRenamedfunctionDto) {
+    return this.renamedfunctionService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.renamedfunctionService.findAll();
+  }
+
+  @Get('with-relations')
+  findAllWithRelations() {
+    return this.renamedfunctionService.findAllWithRelations();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.renamedfunctionService.findOne(id);
+  }
+
+  @Get(':id/with-relations')
+  findOneWithRelations(@Param('id', ParseIntPipe) id: number) {
+    return this.renamedfunctionService.findOneWithRelations(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateRenamedfunctionDto) {
+    return this.renamedfunctionService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.renamedfunctionService.remove(id);
+  }
+}

--- a/backend/server/src/renamedfunction/renamedfunction.module.ts
+++ b/backend/server/src/renamedfunction/renamedfunction.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RenamedfunctionService } from './renamedfunction.service';
+import { RenamedfunctionController } from './renamedfunction.controller';
+
+@Module({
+  controllers: [RenamedfunctionController],
+  providers: [RenamedfunctionService],
+  exports: [RenamedfunctionService],
+})
+export class RenamedfunctionModule {}

--- a/backend/server/src/renamedfunction/renamedfunction.service.ts
+++ b/backend/server/src/renamedfunction/renamedfunction.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateRenamedfunctionDto } from './dto/create-renamedfunction.dto';
+import { UpdateRenamedfunctionDto } from './dto/update-renamedfunction.dto';
+
+@Injectable()
+export class RenamedfunctionService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateRenamedfunctionDto) {
+    const data: any = {
+      function_id: dto.function_id,
+      building_id: dto.building_id ?? undefined,
+      name: dto.name ?? undefined,
+    };
+    return this.prisma.renamedfunction.create({ data });
+  }
+
+  async findAll() {
+    return this.prisma.renamedfunction.findMany();
+  }
+
+  async findOne(function_id: number) {
+    const renamedfunction = await this.prisma.renamedfunction.findUnique({ where: { function_id } });
+    if (!renamedfunction) throw new NotFoundException(`Function ${function_id} not found`);
+    return renamedfunction;
+  }
+
+  async findAllWithRelations() {
+    return this.prisma.renamedfunction.findMany({
+      include: {
+        building: true,
+        job: {
+          include: {
+            job_level: true,
+            job_skill: { include: { skill: true } },
+            job_task: { include: { task: true } },
+            people: true,
+          },
+        },
+      },
+    });
+  }
+
+  async findOneWithRelations(function_id: number) {
+    const renamedfunction = await this.prisma.renamedfunction.findUnique({
+      where: { function_id },
+      include: {
+        building: true,
+        job: {
+          include: {
+            job_level: true,
+            job_skill: { include: { skill: true } },
+            job_task: { include: { task: true } },
+            people: true,
+          },
+        },
+      },
+    });
+    if (!renamedfunction) throw new NotFoundException(`Function ${function_id} not found`);
+    return renamedfunction;
+  }
+
+  async update(function_id: number, dto: UpdateRenamedfunctionDto) {
+    const data: any = {
+      building_id: dto.building_id ?? undefined,
+      name: dto.name ?? undefined,
+    };
+    return this.prisma.renamedfunction.update({ where: { function_id }, data });
+  }
+
+  async remove(function_id: number) {
+    return this.prisma.renamedfunction.delete({ where: { function_id } });
+  }
+}


### PR DESCRIPTION
### Summary
Added full CRUD functionality for the RenamedFunction module.

### Details
- Created DTOs for RenamedFunction.
- Implemented service with CRUD methods and `with-relations`:
  - Includes building
  - Includes jobs → job_level, skills, tasks, people
- Added controller endpoints for CRUD + `/with-relations`.
- Registered RenamedFunction module in `app.module.ts`.

### Notes
- Ensures deep relational queries for RenamedFunction entity.
- Prepares system for complex organizational function hierarchies.
