### PR TITLE
feat: implement Process CRUD module

### DIFF
--- a/backend/server/src/app.module.ts
+++ b/backend/server/src/app.module.ts
@@ -9,9 +9,10 @@ import { RoomModule } from './room/room.module';
 import { TableModule } from './table/table.module';
 import { RenamedfunctionModule } from './renamedfunction/renamedfunction.module';
 import { JobModule } from './job/job.module';
+import { ProcessModule } from './process/process.module';
 
 @Module({
-  imports: [PrismaModule, CompanyModule, BuildingModule, FloorModule, RoomModule, TableModule, RenamedfunctionModule, JobModule],
+  imports: [PrismaModule, CompanyModule, BuildingModule, FloorModule, RoomModule, TableModule, RenamedfunctionModule, JobModule, ProcessModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/server/src/process/dto/create-process.dto.ts
+++ b/backend/server/src/process/dto/create-process.dto.ts
@@ -1,0 +1,23 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class CreateProcessDto {
+  // Required because `process_id` has no autoincrement in Prisma schema
+  @IsInt()
+  process_id!: number;
+
+  @IsOptional()
+  @IsInt()
+  building_id?: number | null;
+
+  @IsOptional()
+  @IsString()
+  name?: string | null;
+
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @IsOptional()
+  @IsInt()
+  duration?: number | null;
+}

--- a/backend/server/src/process/dto/update-process.dto.ts
+++ b/backend/server/src/process/dto/update-process.dto.ts
@@ -1,0 +1,19 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class UpdateProcessDto {
+  @IsOptional()
+  @IsInt()
+  building_id?: number | null;
+
+  @IsOptional()
+  @IsString()
+  name?: string | null;
+
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @IsOptional()
+  @IsInt()
+  duration?: number | null;
+}

--- a/backend/server/src/process/process.controller.ts
+++ b/backend/server/src/process/process.controller.ts
@@ -1,0 +1,62 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post } from '@nestjs/common';
+import { ProcessService } from './process.service';
+import { CreateProcessDto } from './dto/create-process.dto';
+import { UpdateProcessDto } from './dto/update-process.dto';
+
+@Controller('process')
+export class ProcessController {
+  constructor(private readonly processService: ProcessService) {}
+
+  @Post()
+  create(@Body() dto: CreateProcessDto) {
+    return this.processService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.processService.findAll();
+  }
+
+  @Get('with-relations')
+  findAllWithRelations() {
+    return this.processService.findAllWithRelations();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.processService.findOne(id);
+  }
+
+  @Get(':id/with-relations')
+  findOneWithRelations(@Param('id', ParseIntPipe) id: number) {
+    return this.processService.findOneWithRelations(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateProcessDto) {
+    return this.processService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.processService.remove(id);
+  }
+
+  // Connect/Disconnect endpoints for tasks
+  @Post(':id/tasks')
+  connectTask(
+    @Param('id', ParseIntPipe) id: number,
+    @Body('task_id', ParseIntPipe) task_id: number,
+    @Body('order') order?: number,
+  ) {
+    return this.processService.connectTask(id, task_id, order);
+  }
+
+  @Delete(':id/tasks/:taskid')
+  disconnectTask(
+    @Param('id', ParseIntPipe) id: number,
+    @Param('taskid', ParseIntPipe) taskid: number,
+  ) {
+    return this.processService.disconnectTask(id, taskid);
+  }
+}

--- a/backend/server/src/process/process.module.ts
+++ b/backend/server/src/process/process.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProcessService } from './process.service';
+import { ProcessController } from './process.controller';
+
+@Module({
+  controllers: [ProcessController],
+  providers: [ProcessService],
+  exports: [ProcessService],
+})
+export class ProcessModule {}

--- a/backend/server/src/process/process.service.ts
+++ b/backend/server/src/process/process.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateProcessDto } from './dto/create-process.dto';
+import { UpdateProcessDto } from './dto/update-process.dto';
+
+@Injectable()
+export class ProcessService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateProcessDto) {
+    const data: any = {
+      process_id: dto.process_id,
+      building_id: dto.building_id ?? undefined,
+      name: dto.name ?? undefined,
+      description: dto.description ?? undefined,
+      duration: dto.duration ?? undefined,
+    };
+    return this.prisma.process.create({ data });
+  }
+
+  async findAll() {
+    return this.prisma.process.findMany();
+  }
+
+  async findOne(process_id: number) {
+    const process = await this.prisma.process.findUnique({ where: { process_id } });
+    if (!process) throw new NotFoundException(`Process ${process_id} not found`);
+    return process;
+  }
+
+  async findAllWithRelations() {
+    return this.prisma.process.findMany({
+      include: {
+        building: true,
+        process_task: {
+          include: {
+            task: {
+              include: {
+                task_skill: { include: { skill: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  async findOneWithRelations(process_id: number) {
+    const process = await this.prisma.process.findUnique({
+      where: { process_id },
+      include: {
+        building: true,
+        process_task: {
+          include: {
+            task: {
+              include: {
+                task_skill: { include: { skill: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+    if (!process) throw new NotFoundException(`Process ${process_id} not found`);
+    return process;
+  }
+
+  async update(process_id: number, dto: UpdateProcessDto) {
+    const data: any = {
+      building_id: dto.building_id ?? undefined,
+      name: dto.name ?? undefined,
+      description: dto.description ?? undefined,
+      duration: dto.duration ?? undefined,
+    };
+    return this.prisma.process.update({ where: { process_id }, data });
+  }
+
+  async remove(process_id: number) {
+    return this.prisma.process.delete({ where: { process_id } });
+  }
+
+  // Connect/Disconnect methods for tasks
+  async connectTask(process_id: number, task_id: number, order?: number) {
+    // Check if process exists
+    await this.findOne(process_id);
+    
+    return this.prisma.process_task.create({
+      data: { 
+        process_id, 
+        task_id,
+        order: order ?? undefined,
+      },
+      include: { task: true },
+    });
+  }
+
+  async disconnectTask(process_id: number, task_id: number) {
+    // Check if process exists
+    await this.findOne(process_id);
+    
+    return this.prisma.process_task.delete({
+      where: { process_id_task_id: { process_id, task_id } },
+    });
+  }
+}


### PR DESCRIPTION
### Overview
This PR adds the Process module with full CRUD support and relational queries.

### Changes
- Added DTOs: create-process.dto.ts, update-process.dto.ts
- Added process.service.ts with:
  - Standard CRUD
  - `with-relations` including building, process_task → task → task_skill → skill
  - Connect/disconnect endpoints for tasks
- Added process.controller.ts with REST endpoints
- Added process.module.ts for module registration

### Endpoints
- CRUD: /process
- With relations: /process/with-relations
- Connect task: POST /process/:id/tasks
- Disconnect task: DELETE /process/:id/tasks/:taskId

### Notes
This completes TASK 8.
